### PR TITLE
[Payment] Accounts that are Past due. CC, cannot be updated. #433

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,13 @@ You'll also need to make this attribute mass-assignable:
       include Koudoku::Plan
       attr_accessible :interval
     end
+
+## Version 0.0.16
+
+Fixed updating credit card as default. There was issue Accounts that are Past due. CC, cannot be updated.
+
+1. User creates a CF account and makes a valid payment.
+2. After x months' user's CC goes out of date or is declined for another reason.
+3. User loses access to their funnel dashboard.
+4. When user logs back in, they are presented with a choice to choose a new plan.
+5. They enter new CC info and select a plan.

--- a/lib/koudoku/version.rb
+++ b/lib/koudoku/version.rb
@@ -1,3 +1,3 @@
 module Koudoku
-  VERSION = "0.0.15"
+  VERSION = "0.0.16"
 end


### PR DESCRIPTION
Fixed updating credit card as default. There was issue Accounts that are Past due. CC, cannot be updated.
