### PR TITLE
Raise abort to signify failure is no longer sufficient in Rails 5.x.

### DIFF
--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -59,7 +59,7 @@ module Koudoku::Subscription
             rescue Stripe::CardError => card_error
               errors[:base] << card_error.message
               card_was_declined
-              return false
+              throw :abort
             end
           # if no plan has been selected.
           else
@@ -126,7 +126,7 @@ module Koudoku::Subscription
             rescue Stripe::CardError => card_error
               errors[:base] << card_error.message
               card_was_declined
-              return false
+              throw :abort
             end
 
             finalize_new_subscription!


### PR DESCRIPTION
Returning false to signify failure is no longer sufficient in Rails 5.x.
You now need to throw :abort ala: https://api.rubyonrails.org/classes/ActiveRecord/Callbacks.html#module-ActiveRecord::Callbacks-label-Canceling+callbacks