### PR TITLE
[169836691] Fix update default credit card bug

### DIFF
--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -194,6 +194,10 @@ module Koudoku::Subscription
     customer = Stripe::Customer.retrieve(self.stripe_id)
     source = customer.sources.create(source: credit_card_token)
     customer.default_source = source.id
+    # Undo payment_method set by the payment_methods API as this will override the default_source
+    if !customer.invoice_settings.default_payment_method.nil?
+      customer.invoice_settings.default_payment_method = nil
+    end
     customer.save
 
     # update the last four based on this new card.


### PR DESCRIPTION
Remove `invoice_settings.default_payment_method` before updating a `customer`s `default_source`, because if it has been set by the payment_method API (as is done by chargedesk), then that previous `payment_method` will take precedence over the newly set `customer.default_source`.

Related ticket: https://www.pivotaltracker.com/story/show/169836691