### PR TITLE
Adding metadata to the customer plan upgrade call.

### DIFF
--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -126,6 +126,7 @@ module Koudoku::Subscription
               @skip_proccessing_callback = false
 
               # now that we have recorded the stripe_id in our system we can setup the subscription in stripe
+              customer.metadata = subscription_options({})[:metadata]
               customer.plan = plan.stripe_id
               customer.save
             rescue Stripe::CardError => card_error


### PR DESCRIPTION
We want to be able to backtrack where customer subscription changes originated from.

Koudoku has a callback called subscription_options that mothership will now use to provide a metadata field. Apply that field to the customer update w/ plans change.

The metadata field will be enriched by `subscription_options` to have the stacktrace of the caller
